### PR TITLE
Add maintenance mode notice for iOS

### DIFF
--- a/src/1-cardinalkit-app/README.md
+++ b/src/1-cardinalkit-app/README.md
@@ -1,5 +1,9 @@
 # CardinalKit iOS app
 
+::: tip
+The CardinalKit iOS template application is in maintenance mode as of July 2023. All new projects should use [Stanford Spezi](https://spezi.stanford.edu), our modular and standards-based framework successor to CardinalKit. Check out the [Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication) as a great way to get started.
+:::
+
 In this section, we will guide you through setting up a new CardinalKit iOS app using the open-source template available on our Github. You will need a Macintosh computer.
 
 Go to [Create a New CardinalKit iOS App](/cardinalkit-docs/1-cardinalkit-app/1-start.html) to get started.


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add maintenance mode notice for iOS

## :recycle: Current situation & Problem
The CardinalKit iOS template is in maintenance mode and new projects should be redirected to Spezi and the Spezi Template Application instead.

## :bulb: Proposed solution
Updates the CardinalKit documentation to reflect the above.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

